### PR TITLE
add call to generated and download the generated pdf report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:18
 
+# install tools
+# - jq: needed by script to parse json
+# - wget: download files
+ENV DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y jq wget
+
 # Prepare entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Requirements
 
-* Have an account on TestMachine.
-* You have a valid API token from TestMachine.
-* You have already created a repository in TestMachine and have the repository id
-* There is at least one .sol file in the repository where you will setup this github action
+- Have an account on TestMachine.
+- You have a valid API token from TestMachine.
+- You have already created a repository in TestMachine and have the repository id
+- There is at least one .sol file in the repository where you will setup this github action
 
 ## Usage
 
@@ -25,22 +25,27 @@ jobs:
   tmscan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: TestMachine Scan
-      uses: testmachine-ai/github-action@main
-      with:
-        # All arguments are required
-        # TM_REPOSITORY_ID: Use an already existing repository id (in this example: 120)
-        # TM_SOURCE: The .sol file (or .zip with many .sol files inside) that you want to analyze (in this example: hello.sol)        
-        TM_REPOSITORY_ID: 120
-        TM_SOURCE: hello.sol
-      env:
-        # All env variables are required
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TM_TOKEN_KEY: ${{ secrets.TM_TOKEN_KEY }}
-        TM_API_URL: ${{ secrets.TM_API_URL }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TestMachine Scan
+        uses: testmachine-ai/github-action@main
+        with:
+          # All arguments are required
+          # TM_REPOSITORY_ID: Use an already existing repository id (in this example: 120)
+          # TM_SOURCE: The .sol file (or .zip with many .sol files inside) that you want to analyze (in this example: hello.sol)
+          TM_REPOSITORY_ID: 120
+          TM_SOURCE: hello.sol
+        env:
+          # All env variables are required
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TM_TOKEN_KEY: ${{ secrets.TM_TOKEN_KEY }}
+          TM_API_URL: ${{ secrets.TM_API_URL }}
+      - name: Upload result
+        uses: actions/upload-artifact@v3
+        with:
+          name: result-report
+          path: action_work_result_report.pdf
 ```
 
 ### Secrets
@@ -48,7 +53,6 @@ jobs:
 - `TM_TOKEN_KEY`: This is the token from TestMachine. You can set a Github action secret in the "Secrets" settings page of your repository.
 - `TM_API_URL`: URL of the TestMachine API assigned to you by the TestMachine team
 - `GITHUB_TOKEN`: Provided by Github (see [Authenticating with the GITHUB_TOKEN](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token)).
-
 
 ## Have question or feedback?
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,6 @@ if [[ -z "${TM_API_URL}" ]]; then
   exit 1
 fi
 
-npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot create-analyze --repo-id ${1} --file ${2}
-
 # overview of process: create a snapshot with the input source, analyze it, then download the result as a pdf report
 
 echo "Create a snapshot"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,3 +13,31 @@ if [[ -z "${TM_API_URL}" ]]; then
 fi
 
 npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot create-analyze --repo-id ${1} --file ${2}
+
+# overview of process: create a snapshot with the input source, analyze it, then download the result as a pdf report
+
+echo "Create a snapshot"
+COMMAND_OUTPUT=$(npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot create --repo-id ${1} --file ${2} --output=json)
+
+# attempt parse json output from previous command, show error in console if failed to parse
+SNAPSHOT_ID=$(jq '.ID' <<< "$COMMAND_OUTPUT") || echo "Cannot parse output from command because: $COMMAND_OUTPUT"
+if [[ ! -z $SNAPSHOT_ID && $SNAPSHOT_ID != "null" ]]; then
+    echo "Created Snapshot Id for analysis: $SNAPSHOT_ID"
+    COMMAND_OUTPUT=$(npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot analyze --snapshot-id=${SNAPSHOT_ID} --output=json)
+    # attempt parse json output from previous command, show error in console if failed to parse
+    ANA_ID=$(jq '.id' <<< "$COMMAND_OUTPUT")
+    if [[ ! -z $ANA_ID && $ANA_ID != "null" ]]; then
+        echo "Requesting report for generated Analysis Id: $ANA_ID"
+        COMMAND_OUTPUT=$(npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} analyses report --analysis-id=${ANA_ID} --output=json)
+        # attempt parse json output from previous command, show error in console if failed to parse
+        DOWNLOAD_URL=$(jq '.downloadURLOfGeneratedReport' <<< "$COMMAND_OUTPUT")
+        if [[ ! -z $DOWNLOAD_URL && $DOWNLOAD_URL != "null" ]]; then
+            # remove double quotes from beginning and end of download url
+            temp="${DOWNLOAD_URL%\"}"
+            DOWNLOAD_URL="${temp#\"}"
+            # download file
+            echo "Downloading generated report PDF download URL: $DOWNLOAD_URL"
+            wget -O action_work_result_report.pdf ${DOWNLOAD_URL}
+        fi
+    fi
+fi


### PR DESCRIPTION
Allow the github action to download the generated pdf report

The PRs for  [cli](https://github.com/testmachine-ai/cli/pull/17) and [api](https://github.com/testmachine-ai/api/pull/59) that generate the pdf report needs to be merged first for this PR to work