### PR TITLE
make tm-api-url optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ jobs:
           # All env variables are required
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TM_TOKEN_KEY: ${{ secrets.TM_TOKEN_KEY }}
-          TM_API_URL: ${{ secrets.TM_API_URL }}
       - name: Upload result
         uses: actions/upload-artifact@v3
         with:
@@ -51,7 +50,6 @@ jobs:
 ### Secrets
 
 - `TM_TOKEN_KEY`: This is the token from TestMachine. You can set a Github action secret in the "Secrets" settings page of your repository.
-- `TM_API_URL`: URL of the TestMachine API assigned to you by the TestMachine team
 - `GITHUB_TOKEN`: Provided by Github (see [Authenticating with the GITHUB_TOKEN](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token)).
 
 ## Have question or feedback?

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: Test and attack your solidity smart contracts with AI.
 inputs:
   tm_repository_id:
     description: Repository Id in TestMachine
-    required: true    
+    required: true
   tm_source:
     description: The file to be sent to TestMachine
     required: true
@@ -13,7 +13,7 @@ runs:
   image: Dockerfile
   args:
     - ${{ inputs.tm_repository_id }}
-    - ${{ inputs.tm_source }}        
+    - ${{ inputs.tm_source }}
 #
 branding:
   icon: check

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,10 +7,6 @@ if [[ -z "${TM_TOKEN_KEY}" ]]; then
   exit 1
 fi
 
-if [[ -z "${TM_API_URL}" ]]; then
-  echo "Error: missing TM_API_URL env variable"
-  exit 1
-fi
 
 # overview of process: create a snapshot with the input source, analyze it, then download the result as a pdf report
 


### PR DESCRIPTION
Small update just to make the tm-api-url optional (so it will use the default one provided by the CLI)