### PR TITLE
update tool for github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ jobs:
         with:
           # All arguments are required
           # TM_REPOSITORY_ID: Use an already existing repository id (in this example: 120)
-          # TM_SOURCE: The .sol file (or .zip with many .sol files inside) that you want to analyze (in this example: hello.sol)
+          # TM_SOURCE: The json file (or .zip with many .json files inside) that you want to analyze (in this example: ourContracts.zip)
           TM_REPOSITORY_ID: 120
-          TM_SOURCE: hello.sol
+          TM_SOURCE: ourContracts.zip
         env:
           # All env variables are required
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,6 @@ if [[ -z "${TM_TOKEN_KEY}" ]]; then
   exit 1
 fi
 
-
 # overview of process: create a snapshot with the input source, analyze it, then download the result as a pdf report
 
 echo "Create a snapshot"
@@ -17,7 +16,7 @@ COMMAND_OUTPUT=$(npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot create --re
 SNAPSHOT_ID=$(jq '.ID' <<< "$COMMAND_OUTPUT") || echo "Cannot parse output from command because: $COMMAND_OUTPUT"
 if [[ ! -z $SNAPSHOT_ID && $SNAPSHOT_ID != "null" ]]; then
     echo "Created Snapshot Id for analysis: $SNAPSHOT_ID"
-    COMMAND_OUTPUT=$(npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot analyze --snapshot-id=${SNAPSHOT_ID} --output=json)
+    COMMAND_OUTPUT=$(npx @testmachine.ai/cli -t ${TM_TOKEN_KEY} snapshot analyze --tools cbt --snapshot-id=${SNAPSHOT_ID} --output=json)
     # attempt parse json output from previous command, show error in console if failed to parse
     ANA_ID=$(jq '.id' <<< "$COMMAND_OUTPUT")
     if [[ ! -z $ANA_ID && $ANA_ID != "null" ]]; then


### PR DESCRIPTION
This update makes the github action run an analysis using the cbt tool because it is the one that creates a quick result that can be immediately sent to the pdf generator.

Tested using the new version of the audit builder https://github.com/testmachine-ai/audit_builder/pull/42

A test run was executed and the pdf obtained from the github action can be seen here  https://github.com/raldozamora/blue-ga-user/actions/runs/5964205243   ( it is in the artifacts section of the screen, as result-report.zip ) 

This PR should only be merged after these two PRs are merged:
- https://github.com/testmachine-ai/audit_builder/pull/42
- https://github.com/testmachine-ai/api/pull/164